### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loader: 'babel',
+        loader: 'babel-loader',
         query: {
           presets: ['es2015','react']
         }


### PR DESCRIPTION
 loader: 'babel'
打包时会报错 :
ERROR in Entry module not found: Error: Can't resolve 'babel' in '/Users/huchunyuan/Documents/Code/Web/React/studyReact/abc'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel'.

改成
loader: 'babel-loader''
打包才能成功